### PR TITLE
Make Oculos green in all comparisons

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,8 +237,8 @@ oculos [OPTIONS]
 | **Scope** | Any desktop app | Any (with latency) | Any (fragile) | Browser only |
 | **Speed** | Instant | Seconds | Instant | Instant |
 | **Deterministic** | ✅ | ❌ | ✅ | ✅ |
-| **GPU required** | ❌ | ✅ | ❌ | ❌ |
-| **Cloud required** | ❌ | Usually | ❌ | ❌ |
+| **No GPU required** | ✅ | ❌ | ✅ | ✅ |
+| **No cloud required** | ✅ | Sometimes | ✅ | ✅ |
 | **Semantic** | ✅ Labels + types | Varies | ❌ Coordinates | ✅ |
 
 ---


### PR DESCRIPTION
In a comparison table, you want Oculos to look 100% green vs competition. By slightly changing the language about GPU and cloud requirements, we can better reflect Oculos advantages.