### PR TITLE
feat: add Bearer token API key authentication

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,9 @@ clap = { version = "4", features = ["derive"] }
 # Lazy statics
 once_cell = "1"
 
+# Random key generation
+rand = "0.8"
+
 # Image encoding (PNG screenshots)
 image = "0.25"
 

--- a/README.md
+++ b/README.md
@@ -104,19 +104,19 @@ OculOS reads the OS accessibility tree and assigns each UI element a session-sco
 
 ```bash
 # 1. List open windows
-curl http://localhost:7878/windows
+curl -H "Authorization: Bearer $OCULOS_API_KEY" http://localhost:7878/windows
 
 # 2. Get the UI tree for a window
-curl http://localhost:7878/windows/{pid}/tree
+curl -H "Authorization: Bearer $OCULOS_API_KEY" http://localhost:7878/windows/{pid}/tree
 
 # 3. Find a specific element
-curl "http://localhost:7878/windows/{pid}/find?q=Submit&type=Button"
+curl -H "Authorization: Bearer $OCULOS_API_KEY" "http://localhost:7878/windows/{pid}/find?q=Submit&type=Button"
 
 # 4. Click it
-curl -X POST http://localhost:7878/interact/{id}/click
+curl -H "Authorization: Bearer $OCULOS_API_KEY" -X POST http://localhost:7878/interact/{id}/click
 
 # 5. Type into a text field
-curl -X POST http://localhost:7878/interact/{id}/set-text \
+curl -H "Authorization: Bearer $OCULOS_API_KEY" -X POST http://localhost:7878/interact/{id}/set-text \
   -H "Content-Type: application/json" \
   -d '{"text":"hello world"}'
 ```
@@ -137,6 +137,8 @@ Every element includes an `actions` array — the API tells you exactly what you
 ---
 
 ## API
+
+> All endpoints require authentication. Include `Authorization: Bearer <KEY>` header with every request.
 
 ### Discovery
 
@@ -293,8 +295,60 @@ oculos [OPTIONS]
       --static-dir <DIR>  Static files directory [default: static]
       --log <LEVEL>       Log level: trace/debug/info/warn/error [default: info]
       --mcp               Run as MCP server over stdin/stdout
+      --api-key <KEY>     API key for HTTP auth [env: OCULOS_API_KEY]
   -h, --help              Print help
 ```
+
+---
+
+## Authentication
+
+All HTTP API endpoints, WebSocket connections, and the Dashboard require a Bearer token.
+
+### How it works
+
+- On startup, if no key is provided, OculOS generates a random one and prints it:
+  ```
+  [OculOS] No API key provided. Generated key: oculos_a1b2c3...
+  [OculOS] Pass it with --api-key or set OCULOS_API_KEY env variable.
+  ```
+- You can provide your own key via CLI or environment variable:
+  ```bash
+  # CLI flag
+  oculos --api-key "my-secret-key"
+
+  # Environment variable
+  export OCULOS_API_KEY="my-secret-key"
+  oculos
+  ```
+
+### Using the API with auth
+
+Pass the key in the `Authorization` header:
+
+```bash
+# List windows
+curl -H "Authorization: Bearer oculos_a1b2c3..." http://localhost:7878/windows
+
+# Get UI tree
+curl -H "Authorization: Bearer oculos_a1b2c3..." http://localhost:7878/windows/1234/tree
+
+# Click an element
+curl -X POST -H "Authorization: Bearer oculos_a1b2c3..." \
+     http://localhost:7878/interact/<element-id>/click
+```
+
+### Dashboard
+
+The web dashboard prompts for the API key on first visit. The key is saved in `localStorage` for the session. If the key becomes invalid (401 response), the login screen reappears.
+
+### WebSocket
+
+Browser WebSocket API cannot send custom headers. The dashboard passes the token via query parameter: `ws://host/ws?token=<KEY>`. The `Authorization: Bearer` header also works for non-browser clients.
+
+### MCP mode
+
+MCP runs over stdin/stdout and does not use HTTP, so no API key is required in `--mcp` mode.
 
 ---
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -2,9 +2,11 @@ pub mod interact;
 pub mod windows;
 pub mod ws;
 
+use crate::auth::{self, ApiKey};
 use crate::platform::UiBackend;
 use crate::types::ApiResponse;
 use axum::{
+    middleware,
     routing::{get, post},
     Json, Router,
 };
@@ -21,9 +23,11 @@ pub struct AppState {
     pub ws_tx: ws::WsBroadcast,
 }
 
-pub fn router(state: AppState) -> Router {
+pub fn router(state: AppState, api_key: String) -> Router {
     // Touch the lazy so uptime starts counting from server boot.
     Lazy::force(&START_TIME);
+
+    let key_ext = ApiKey(api_key);
 
     Router::new()
         // ── Discovery ──────────────────────────────────────────────────────
@@ -62,6 +66,9 @@ pub fn router(state: AppState) -> Router {
         .route("/health", get(health))
         // ── WebSocket ─────────────────────────────────────────────────────
         .route("/ws", get(ws::ws_handler))
+        // ── Auth middleware (applies to all routes above) ─────────────────
+        .layer(middleware::from_fn(auth::auth_middleware))
+        .layer(axum::Extension(key_ext))
         .with_state(state)
 }
 

--- a/src/api/ws.rs
+++ b/src/api/ws.rs
@@ -37,7 +37,9 @@ pub fn create_broadcast() -> WsBroadcast {
     Arc::new(tx)
 }
 
-/// GET /ws — upgrade to WebSocket
+/// GET /ws — upgrade to WebSocket.
+/// Auth is handled by the auth middleware layer (supports both
+/// `Authorization: Bearer` header and `?token=` query parameter).
 pub async fn ws_handler(ws: WebSocketUpgrade, State(s): State<AppState>) -> impl IntoResponse {
     ws.on_upgrade(move |socket| handle_socket(socket, s))
 }

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,0 +1,129 @@
+//! Bearer token authentication middleware for OculOS HTTP API.
+
+use axum::{
+    extract::Request,
+    http::StatusCode,
+    middleware::Next,
+    response::{IntoResponse, Response},
+    Json,
+};
+use serde_json::json;
+use tracing::info;
+
+/// Resolve the API key: use the provided value, or generate a random one.
+pub fn resolve_api_key(provided: Option<String>) -> String {
+    match provided {
+        Some(key) if !key.is_empty() => {
+            info!("[OculOS] Using provided API key.");
+            key
+        }
+        _ => {
+            let key = generate_key();
+            info!("[OculOS] No API key provided. Generated key: {}", key);
+            info!("[OculOS] Pass it with --api-key or set OCULOS_API_KEY env variable.");
+            key
+        }
+    }
+}
+
+/// Generate a cryptographically random API key: `oculos_<32 bytes hex>`.
+fn generate_key() -> String {
+    use rand::Rng;
+    let mut bytes = [0u8; 32];
+    rand::thread_rng().fill(&mut bytes);
+    format!("oculos_{}", hex_encode(&bytes))
+}
+
+fn hex_encode(bytes: &[u8]) -> String {
+    bytes.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+/// Axum middleware that validates the API key on every request.
+///
+/// Checks in order:
+/// 1. `Authorization: Bearer <KEY>` header
+/// 2. `?token=<KEY>` query parameter (needed for browser WebSocket connections)
+pub async fn auth_middleware(request: Request, next: Next) -> Response {
+    let expected = request
+        .extensions()
+        .get::<ApiKey>()
+        .map(|k| k.0.clone());
+
+    let expected = match expected {
+        Some(k) => k,
+        None => return (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({"error": "Internal Server Error", "message": "Auth not configured"}))).into_response(),
+    };
+
+    // 1. Check Authorization header
+    let header_key = request
+        .headers()
+        .get("authorization")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|h| h.strip_prefix("Bearer "));
+
+    if let Some(key) = header_key {
+        if constant_time_eq(key, &expected) {
+            return next.run(request).await;
+        }
+    }
+
+    // 2. Check ?token= query parameter (for WebSocket from browsers)
+    if let Some(query) = request.uri().query() {
+        for pair in query.split('&') {
+            if let Some(value) = pair.strip_prefix("token=") {
+                let decoded = urlencoding_decode(value);
+                if constant_time_eq(&decoded, &expected) {
+                    return next.run(request).await;
+                }
+            }
+        }
+    }
+
+    (
+        StatusCode::UNAUTHORIZED,
+        Json(json!({
+            "error": "Unauthorized",
+            "message": "Invalid or missing API key"
+        })),
+    )
+        .into_response()
+}
+
+/// Minimal percent-decoding for the token query parameter.
+fn urlencoding_decode(s: &str) -> String {
+    let mut result = String::with_capacity(s.len());
+    let mut chars = s.bytes();
+    while let Some(b) = chars.next() {
+        if b == b'%' {
+            let hi = chars.next().unwrap_or(0);
+            let lo = chars.next().unwrap_or(0);
+            if let (Some(h), Some(l)) = (hex_val(hi), hex_val(lo)) {
+                result.push((h << 4 | l) as char);
+            }
+        } else if b == b'+' {
+            result.push(' ');
+        } else {
+            result.push(b as char);
+        }
+    }
+    result
+}
+
+fn hex_val(b: u8) -> Option<u8> {
+    match b {
+        b'0'..=b'9' => Some(b - b'0'),
+        b'a'..=b'f' => Some(b - b'a' + 10),
+        b'A'..=b'F' => Some(b - b'A' + 10),
+        _ => None,
+    }
+}
+
+/// Constant-time string comparison to prevent timing attacks.
+fn constant_time_eq(a: &str, b: &str) -> bool {
+    if a.len() != b.len() { return false; }
+    a.bytes().zip(b.bytes()).fold(0u8, |acc, (x, y)| acc | (x ^ y)) == 0
+}
+
+/// Newtype wrapper so we can insert the key into request extensions.
+#[derive(Clone)]
+pub struct ApiKey(pub String);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod api;
+mod auth;
 mod mcp;
 mod platform;
 mod types;
@@ -39,6 +40,11 @@ struct Args {
     /// Add this binary to your MCP host config (Claude, Cursor, Windsurf…).
     #[arg(long)]
     mcp: bool,
+
+    /// API key for authenticating HTTP requests. If not provided, a random key
+    /// is generated at startup. Can also be set via OCULOS_API_KEY env variable.
+    #[arg(long, env = "OCULOS_API_KEY")]
+    api_key: Option<String>,
 }
 
 #[tokio::main]
@@ -67,6 +73,9 @@ async fn main() -> Result<()> {
         return Ok(());
     }
 
+    // ── API key ───────────────────────────────────────────────────────────────
+    let api_key = auth::resolve_api_key(args.api_key);
+
     let ws_tx = api::ws::create_broadcast();
     let state = AppState { backend, ws_tx };
 
@@ -77,12 +86,12 @@ async fn main() -> Result<()> {
         .allow_headers(Any);
 
     // ── Router ────────────────────────────────────────────────────────────────
-    let api_routes = api::router(state);
+    let api_routes = api::router(state, api_key.clone());
 
     let app = Router::new()
         // API routes under /api namespace (also available at root for simplicity)
         .merge(api_routes)
-        // Dashboard — served at /
+        // Dashboard — served at / (no auth required for static files)
         .nest_service("/", ServeDir::new(&args.static_dir))
         .layer(cors)
         .layer(TraceLayer::new_for_http());

--- a/static/index.html
+++ b/static/index.html
@@ -146,6 +146,17 @@ body{background:var(--bg);color:var(--text);font:13px/1.5 var(--sans);display:fl
 .loading{display:inline-block;width:14px;height:14px;border:2px solid var(--border);border-top-color:var(--blue);border-radius:50%;animation:spin .6s linear infinite}
 @keyframes spin{to{transform:rotate(360deg)}}
 
+/* ── login overlay ── */
+.login-overlay{position:fixed;inset:0;background:var(--bg);z-index:1000;display:none;align-items:center;justify-content:center}
+.login-box{background:var(--surface);border:1px solid var(--border);border-radius:8px;padding:32px;width:360px;text-align:center}
+.login-box h2{font:600 18px var(--sans);color:var(--text);margin-bottom:4px}
+.login-box p{font:13px var(--sans);color:var(--text-3);margin-bottom:20px}
+.login-box input{width:100%;height:36px;background:var(--raised);border:1px solid var(--border);border-radius:4px;padding:0 12px;font:13px var(--mono);color:var(--text);outline:none;margin-bottom:12px}
+.login-box input:focus{border-color:var(--blue)}
+.login-box button{width:100%;height:36px;background:var(--blue);border:none;border-radius:4px;font:500 13px var(--sans);color:#fff;cursor:pointer}
+.login-box button:hover{background:#5a96ff}
+.login-err{color:var(--red);font-size:12px;margin-bottom:8px;display:none}
+
 /* ── toast ── */
 .toast-wrap{position:fixed;bottom:16px;right:16px;display:flex;flex-direction:column;gap:6px;z-index:999;pointer-events:none}
 .toast{padding:8px 14px;border-radius:var(--radius);font:12px var(--sans);color:var(--text);background:var(--raised);border:1px solid var(--border);box-shadow:0 4px 16px rgba(0,0,0,.4);opacity:0;transform:translateY(8px);animation:toast-in .2s forwards}
@@ -187,6 +198,17 @@ body{background:var(--bg);color:var(--text);font:13px/1.5 var(--sans);display:fl
 </style>
 </head>
 <body>
+
+<div class="login-overlay" id="loginOverlay">
+  <div class="login-box">
+    <h2>OculOS</h2>
+    <p>Enter your API key to access the dashboard.</p>
+    <div class="login-err" id="loginErr">Invalid API key. Please try again.</div>
+    <input type="password" id="loginKey" placeholder="oculos_..." autofocus
+           onkeydown="if(event.key==='Enter')doLogin()"/>
+    <button onclick="doLogin()">Authenticate</button>
+  </div>
+</div>
 
 <div class="topbar">
   <svg width="18" height="18" viewBox="0 0 256 256" fill="none" style="vertical-align:middle;margin-right:6px"><g stroke="currentColor" stroke-width="14" stroke-linecap="round" stroke-linejoin="round"><path d="M44 128 C72 90 104 72 128 72 C152 72 184 90 212 128 C184 166 152 184 128 184 C104 184 72 166 44 128 Z"/><path d="M92 104 L76 128 L92 152"/><path d="M164 104 L180 128 L164 152"/><circle cx="128" cy="128" r="10" fill="currentColor" stroke="none"/></g></svg><span class="topbar-brand">OculOS</span>
@@ -288,6 +310,33 @@ body{background:var(--bg);color:var(--text);font:13px/1.5 var(--sans);display:fl
 <script>
 const API='';
 let selWin=null,selElem=null,logN=0,allElements=[],nodeTotal=0;
+let apiKey=localStorage.getItem('oculos_api_key')||'';
+
+// ── auth ──
+function getAuthHeaders(){return {'Content-Type':'application/json','Authorization':'Bearer '+apiKey}}
+function showLogin(){document.getElementById('loginOverlay').style.display='flex'}
+function hideLogin(){document.getElementById('loginOverlay').style.display='none'}
+// Show login immediately if no stored key (avoids flash of empty dashboard)
+if(!apiKey)showLogin();
+async function doLogin(){
+  const k=document.getElementById('loginKey').value.trim();
+  if(!k){document.getElementById('loginErr').textContent='Please enter an API key.';document.getElementById('loginErr').style.display='block';return}
+  try{
+    const r=await fetch(API+'/health',{headers:{'Authorization':'Bearer '+k}});
+    if(r.status===401){document.getElementById('loginErr').textContent='Invalid API key. Please try again.';document.getElementById('loginErr').style.display='block';return}
+    apiKey=k;localStorage.setItem('oculos_api_key',k);
+    document.getElementById('loginErr').style.display='none';
+    hideLogin();initApp();
+  }catch(e){document.getElementById('loginErr').textContent='Server unreachable. Is OculOS running?';document.getElementById('loginErr').style.display='block'}
+}
+async function checkAuth(){
+  if(!apiKey){showLogin();return}
+  try{
+    const r=await fetch(API+'/health',{headers:{'Authorization':'Bearer '+apiKey}});
+    if(r.status===401){apiKey='';localStorage.removeItem('oculos_api_key');resetApp();showLogin();return}
+    hideLogin();initApp();
+  }catch(e){document.getElementById('loginErr').textContent='Server unreachable. Is OculOS running?';document.getElementById('loginErr').style.display='block';showLogin()}
+}
 
 // ── toast ──
 function toast(msg,type='ok'){
@@ -306,9 +355,11 @@ function switchTab(id,el){
 async function api(method,path,body){
   const t0=Date.now();
   try{
-    const opts={method,headers:{'Content-Type':'application/json'}};
+    const opts={method,headers:getAuthHeaders()};
     if(body)opts.body=JSON.stringify(body);
-    const r=await fetch(API+path,opts),d=await r.json();
+    const r=await fetch(API+path,opts);
+    if(r.status===401){apiKey='';localStorage.removeItem('oculos_api_key');resetApp();showLogin();throw new Error('Unauthorized')}
+    const d=await r.json();
     addLog(method,path,r.ok?'ok':'err',Date.now()-t0);
     return d;
   }catch(e){addLog(method,path,'err',Date.now()-t0);throw e}
@@ -606,24 +657,24 @@ function exportAs(lang){
   let code='';
   const base='http://127.0.0.1:7878';
   if(lang==='python'){
-    code='import requests\n\n';
+    code='import requests\n\nHEADERS = {"Authorization": "Bearer YOUR_API_KEY"}\n\n';
     recSteps.forEach((s,i)=>{
       const url=`${base}/interact/${s.id}/${s.action}`;
-      if(s.body)code+=`# Step ${i+1}: ${s.action}\nrequests.post("${url}", json=${JSON.stringify(s.body).replace(/"/g,"'")})\n\n`;
-      else code+=`# Step ${i+1}: ${s.action}\nrequests.post("${url}")\n\n`;
+      if(s.body)code+=`# Step ${i+1}: ${s.action}\nrequests.post("${url}", json=${JSON.stringify(s.body).replace(/"/g,"'")}, headers=HEADERS)\n\n`;
+      else code+=`# Step ${i+1}: ${s.action}\nrequests.post("${url}", headers=HEADERS)\n\n`;
     });
   } else if(lang==='javascript'){
-    code='const API = "http://127.0.0.1:7878";\n\n';
+    code='const API = "http://127.0.0.1:7878";\nconst HEADERS = {"Content-Type":"application/json","Authorization":"Bearer YOUR_API_KEY"};\n\n';
     recSteps.forEach((s,i)=>{
       const path=`/interact/${s.id}/${s.action}`;
-      if(s.body)code+=`// Step ${i+1}: ${s.action}\nawait fetch(API + "${path}", { method: "POST", headers: {"Content-Type":"application/json"}, body: JSON.stringify(${JSON.stringify(s.body)}) });\n\n`;
-      else code+=`// Step ${i+1}: ${s.action}\nawait fetch(API + "${path}", { method: "POST" });\n\n`;
+      if(s.body)code+=`// Step ${i+1}: ${s.action}\nawait fetch(API + "${path}", { method: "POST", headers: HEADERS, body: JSON.stringify(${JSON.stringify(s.body)}) });\n\n`;
+      else code+=`// Step ${i+1}: ${s.action}\nawait fetch(API + "${path}", { method: "POST", headers: HEADERS });\n\n`;
     });
   } else if(lang==='curl'){
     recSteps.forEach((s,i)=>{
       const url=`${base}/interact/${s.id}/${s.action}`;
-      if(s.body)code+=`# Step ${i+1}: ${s.action}\ncurl -s -X POST -H "Content-Type: application/json" -d '${JSON.stringify(s.body)}' "${url}"\n\n`;
-      else code+=`# Step ${i+1}: ${s.action}\ncurl -s -X POST "${url}"\n\n`;
+      if(s.body)code+=`# Step ${i+1}: ${s.action}\ncurl -s -X POST -H "Authorization: Bearer YOUR_API_KEY" -H "Content-Type: application/json" -d '${JSON.stringify(s.body)}' "${url}"\n\n`;
+      else code+=`# Step ${i+1}: ${s.action}\ncurl -s -X POST -H "Authorization: Bearer YOUR_API_KEY" "${url}"\n\n`;
     });
   }
   navigator.clipboard.writeText(code).then(()=>toast(`${lang} script copied (${recSteps.length} steps)`)).catch(()=>{
@@ -632,18 +683,15 @@ function exportAs(lang){
 }
 
 // patch doAction to record
-const _origDoAction=doAction;
 doAction=async function(action,id){
   try{const d=await api('POST',`/interact/${id}/${action}`);if(!d.success)throw new Error(d.error);recAdd(action,id);toast(`${action} OK`)}
   catch(e){toast(`${action}: ${e.message}`,'err')}
 };
-const _origDoSetText=doSetText;
 doSetText=async function(id){
   const v=document.getElementById('txtIn')?.value;if(v==null)return;
   try{const d=await api('POST',`/interact/${id}/set-text`,{text:v});if(!d.success)throw new Error(d.error);recAdd('set-text',id,{text:v});toast('Text set')}
   catch(e){toast('Set text: '+e.message,'err')}
 };
-const _origDoSendKeys=doSendKeys;
 doSendKeys=async function(id){
   const v=document.getElementById('keysIn')?.value;if(!v)return;
   try{const d=await api('POST',`/interact/${id}/send-keys`,{keys:v});if(!d.success)throw new Error(d.error);recAdd('send-keys',id,{keys:v});toast('Keys sent')}
@@ -653,7 +701,8 @@ doSendKeys=async function(id){
 // ── health / uptime ──
 async function fetchHealth(){
   try{
-    const r=await fetch('/health');
+    const r=await fetch('/health',{headers:{'Authorization':'Bearer '+apiKey}});
+    if(r.status===401)return;
     const d=await r.json();
     if(d.success&&d.data){
       const s=d.data.uptime_secs;
@@ -671,8 +720,9 @@ async function fetchHealth(){
 // ── WebSocket ──
 let ws=null,wsRetry=0;
 function connectWs(){
+  if(!apiKey)return;
   const proto=location.protocol==='https:'?'wss:':'ws:';
-  ws=new WebSocket(`${proto}//${location.host}/ws`);
+  ws=new WebSocket(`${proto}//${location.host}/ws?token=${encodeURIComponent(apiKey)}`);
   ws.onopen=()=>{
     wsRetry=0;
     document.getElementById('wsDot').className='ws-dot on';
@@ -710,11 +760,19 @@ document.addEventListener('keydown',e=>{
 });
 
 // ── init ──
-loadWindows();
-fetchHealth();
-connectWs();
-setInterval(()=>{if(!document.hidden)loadWindows()},10000);
-setInterval(fetchHealth,5000);
+let _initDone=false,_ivWin=0,_ivHealth=0;
+function initApp(){
+  if(_initDone)return;_initDone=true;
+  loadWindows();fetchHealth();connectWs();
+  _ivWin=setInterval(()=>{if(!document.hidden)loadWindows()},10000);
+  _ivHealth=setInterval(fetchHealth,5000);
+}
+function resetApp(){
+  _initDone=false;
+  clearInterval(_ivWin);clearInterval(_ivHealth);
+  if(ws){ws.close();ws=null}
+}
+checkAuth();
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

- Add `--api-key <KEY>` CLI flag and `OCULOS_API_KEY` env var for API authentication
- Auto-generate a cryptographically secure key (`oculos_<32-byte hex>`) when none is provided
- Axum middleware layer enforces `Authorization: Bearer <KEY>` on all HTTP endpoints (`/windows/**`, `/interact/**`, `/hwnd/**`, `/health`, `/ws`)
- Browser WebSocket connections authenticated via `?token=<KEY>` query parameter (since browser WS API cannot send custom headers)
- Dashboard login screen with localStorage persistence; 401 responses trigger automatic logout
- Constant-time key comparison to prevent timing side-channel attacks
- Fail-closed auth design (returns 500 if auth layer is misconfigured)
- MCP mode (`--mcp`) bypasses auth entirely (stdin/stdout, no network involved)
- Recorder-exported scripts (Python/JS/curl) include auth headers
- README updated with full Authentication section and all curl examples updated

## Changed files

| File | Change |
|------|--------|
| `Cargo.toml` | Added `rand = "0.8"` dependency |
| `src/auth.rs` | **New** — key generation, auth middleware, constant-time compare |
| `src/main.rs` | `--api-key` CLI arg, env var, wiring |
| `src/api/mod.rs` | Middleware + Extension layer on router |
| `src/api/ws.rs` | Updated doc comments |
| `static/index.html` | Login overlay, auth headers on all fetches/WS, 401 handling |
| `README.md` | Auth section, updated curl examples, API table auth note |

## Test plan

- [ ] `cargo build` compiles without errors on all 3 platforms
- [ ] Start without `--api-key` → random key printed to console
- [ ] Start with `--api-key mykey` → "Using provided API key" logged
- [ ] Start with `OCULOS_API_KEY=mykey` → same behavior
- [ ] `curl http://localhost:7878/windows` → 401 Unauthorized
- [ ] `curl -H "Authorization: Bearer <key>" http://localhost:7878/windows` → 200 OK
- [ ] Dashboard shows login screen on first visit
- [ ] Wrong key → "Invalid API key" error shown
- [ ] Correct key → dashboard loads, key saved in localStorage
- [ ] Refresh page → auto-login with saved key (no login screen)
- [ ] WebSocket connects with `?token=` and receives events
- [ ] `--mcp` mode works without any auth prompts
- [ ] After server restart with new key → dashboard shows 401, login screen reappears